### PR TITLE
netstat as non root doesn't print program name

### DIFF
--- a/dockerscripts/healthcheck.go
+++ b/dockerscripts/healthcheck.go
@@ -38,7 +38,7 @@ const (
 	initGraceTime = 300
 	healthPath    = "/minio/health/live"
 	timeout       = time.Duration(30 * time.Second)
-	minioProcess  = "minio"
+	tcp           = "tcp"
 )
 
 // returns container boot time by finding
@@ -68,9 +68,16 @@ func findEndpoint() (string, error) {
 	// split netstat output in rows
 	scanner := bufio.NewScanner(stdout)
 	scanner.Split(bufio.ScanLines)
-	// loop over the rows to find MinIO process
+	// MinIO works on TCP and it is supposed to be
+	// the only process listening on a port inside
+	// container. So we take the first row of netstat
+	// output (that has tcp) and assume that is the
+	// MinIO server port.
+	// Since MinIO is running as non-root user, we can
+	// no longer depend on the PID/Program name column
+	// of netstat output
 	for scanner.Scan() {
-		if strings.Contains(scanner.Text(), minioProcess) {
+		if strings.Contains(scanner.Text(), tcp) {
 			line := scanner.Text()
 			newLine := strings.Replace(line, ":::", "127.0.0.1:", 1)
 			fields := strings.Fields(newLine)


### PR DESCRIPTION
Since MinIO is running as non-root user, we can
no longer depend on the PID/Program name column
of netstat output, instead use `tcp` as the filter
to look for MinIO server port in netstat output.