### PR TITLE
Tweaks for bucket metadata

### DIFF
--- a/cmd/admin-handlers-quota.go
+++ b/cmd/admin-handlers-quota.go
@@ -101,7 +101,7 @@ func (a adminAPIHandlers) GetBucketQuotaConfigHandler(w http.ResponseWriter, r *
 		return
 	}
 
-	configData, err := globalBucketMetadataSys.Get(bucket, bucketQuotaConfigFile)
+	configData, err := globalBucketMetadataSys.GetConfig(bucket, bucketQuotaConfigFile)
 	if err != nil {
 		if errors.Is(err, errConfigNotFound) {
 			writeErrorResponseJSON(ctx, w, toAdminAPIErr(ctx, BucketQuotaConfigNotFound{Bucket: bucket}), r.URL)

--- a/cmd/bucket-encryption-handlers.go
+++ b/cmd/bucket-encryption-handlers.go
@@ -128,7 +128,7 @@ func (api objectAPIHandlers) GetBucketEncryptionHandler(w http.ResponseWriter, r
 		return
 	}
 
-	configData, err := globalBucketMetadataSys.Get(bucket, bucketSSEConfig)
+	configData, err := globalBucketMetadataSys.GetConfig(bucket, bucketSSEConfig)
 	if err != nil {
 		if errors.Is(err, errConfigNotFound) {
 			err = BucketSSEConfigNotFound{Bucket: bucket}

--- a/cmd/bucket-encryption.go
+++ b/cmd/bucket-encryption.go
@@ -39,7 +39,7 @@ func NewBucketSSEConfigSys() *BucketSSEConfigSys {
 // load - Loads the bucket encryption configuration for the given list of buckets
 func (sys *BucketSSEConfigSys) load(buckets []BucketInfo, objAPI ObjectLayer) error {
 	for _, bucket := range buckets {
-		configData, err := globalBucketMetadataSys.Get(bucket.Name, bucketSSEConfig)
+		configData, err := globalBucketMetadataSys.GetConfig(bucket.Name, bucketSSEConfig)
 		if err != nil {
 			if errors.Is(err, errConfigNotFound) {
 				continue
@@ -86,7 +86,7 @@ func (sys *BucketSSEConfigSys) Get(bucket string) (config *bucketsse.BucketSSECo
 
 	config, ok := sys.bucketSSEConfigMap[bucket]
 	if !ok {
-		configData, err := globalBucketMetadataSys.Get(bucket, bucketSSEConfig)
+		configData, err := globalBucketMetadataSys.GetConfig(bucket, bucketSSEConfig)
 		if err != nil {
 			if errors.Is(err, errConfigNotFound) {
 				return nil, BucketSSEConfigNotFound{Bucket: bucket}

--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -1060,7 +1060,7 @@ func (api objectAPIHandlers) GetBucketObjectLockConfigHandler(w http.ResponseWri
 		return
 	}
 
-	configData, err := globalBucketMetadataSys.Get(bucket, objectLockConfig)
+	configData, err := globalBucketMetadataSys.GetConfig(bucket, objectLockConfig)
 	if err != nil {
 		if errors.Is(err, errConfigNotFound) {
 			err = BucketObjectLockConfigNotFound{Bucket: bucket}
@@ -1139,7 +1139,7 @@ func (api objectAPIHandlers) GetBucketTaggingHandler(w http.ResponseWriter, r *h
 		return
 	}
 
-	configData, err := globalBucketMetadataSys.Get(bucket, bucketTaggingConfigFile)
+	configData, err := globalBucketMetadataSys.GetConfig(bucket, bucketTaggingConfigFile)
 	if err != nil {
 		if errors.Is(err, errConfigNotFound) {
 			err = BucketTaggingNotFound{Bucket: bucket}

--- a/cmd/bucket-lifecycle-handler.go
+++ b/cmd/bucket-lifecycle-handler.go
@@ -114,7 +114,7 @@ func (api objectAPIHandlers) GetBucketLifecycleHandler(w http.ResponseWriter, r 
 		return
 	}
 
-	configData, err := globalBucketMetadataSys.Get(bucket, bucketLifecycleConfig)
+	configData, err := globalBucketMetadataSys.GetConfig(bucket, bucketLifecycleConfig)
 	if err != nil {
 		if errors.Is(err, errConfigNotFound) {
 			err = BucketLifecycleNotFound{Bucket: bucket}

--- a/cmd/bucket-lifecycle.go
+++ b/cmd/bucket-lifecycle.go
@@ -47,7 +47,7 @@ func (sys *LifecycleSys) Get(bucketName string) (lc *lifecycle.Lifecycle, err er
 
 	lc, ok := sys.bucketLifecycleMap[bucketName]
 	if !ok {
-		configData, err := globalBucketMetadataSys.Get(bucketName, bucketLifecycleConfig)
+		configData, err := globalBucketMetadataSys.GetConfig(bucketName, bucketLifecycleConfig)
 		if err != nil {
 			if errors.Is(err, errConfigNotFound) {
 				return nil, BucketLifecycleNotFound{Bucket: bucketName}
@@ -85,7 +85,7 @@ func (sys *LifecycleSys) Init(buckets []BucketInfo, objAPI ObjectLayer) error {
 // Loads lifecycle policies for all buckets into LifecycleSys.
 func (sys *LifecycleSys) load(buckets []BucketInfo, objAPI ObjectLayer) error {
 	for _, bucket := range buckets {
-		configData, err := globalBucketMetadataSys.Get(bucket.Name, bucketLifecycleConfig)
+		configData, err := globalBucketMetadataSys.GetConfig(bucket.Name, bucketLifecycleConfig)
 		if err != nil {
 			if errors.Is(err, errConfigNotFound) {
 				continue

--- a/cmd/bucket-metadata.go
+++ b/cmd/bucket-metadata.go
@@ -57,8 +57,8 @@ type BucketMetadata struct {
 }
 
 // newBucketMetadata creates BucketMetadata with the supplied name and Created to Now.
-func newBucketMetadata(name string) *BucketMetadata {
-	return &BucketMetadata{
+func newBucketMetadata(name string) BucketMetadata {
+	return BucketMetadata{
 		Name:    name,
 		Created: UTCNow(),
 	}
@@ -93,7 +93,7 @@ func (b *BucketMetadata) Load(ctx context.Context, api ObjectLayer, name string)
 }
 
 // loadBucketMetadata loads and migrates to bucket metadata.
-func loadBucketMetadata(ctx context.Context, objectAPI ObjectLayer, bucket string) (*BucketMetadata, error) {
+func loadBucketMetadata(ctx context.Context, objectAPI ObjectLayer, bucket string) (BucketMetadata, error) {
 	b := newBucketMetadata(bucket)
 	err := b.Load(ctx, objectAPI, bucket)
 	if err == nil {

--- a/cmd/bucket-notification-handlers.go
+++ b/cmd/bucket-notification-handlers.go
@@ -74,7 +74,7 @@ func (api objectAPIHandlers) GetBucketNotificationHandler(w http.ResponseWriter,
 	}
 	config.SetRegion(globalServerRegion)
 
-	configData, err := globalBucketMetadataSys.Get(bucketName, bucketNotificationConfig)
+	configData, err := globalBucketMetadataSys.GetConfig(bucketName, bucketNotificationConfig)
 	if err != nil {
 		if err != errConfigNotFound {
 			writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))

--- a/cmd/bucket-object-lock.go
+++ b/cmd/bucket-object-lock.go
@@ -47,7 +47,7 @@ func (sys *BucketObjectLockSys) Get(bucketName string) (r *objectlock.Retention,
 
 	r, ok := sys.retentionMap[bucketName]
 	if !ok {
-		configData, err := globalBucketMetadataSys.Get(bucketName, objectLockConfig)
+		configData, err := globalBucketMetadataSys.GetConfig(bucketName, objectLockConfig)
 		if err != nil {
 			if errors.Is(err, errConfigNotFound) {
 				return &objectlock.Retention{}, nil
@@ -442,7 +442,7 @@ func (sys *BucketObjectLockSys) Init(buckets []BucketInfo, objAPI ObjectLayer) e
 func (sys *BucketObjectLockSys) load(buckets []BucketInfo, objAPI ObjectLayer) error {
 	for _, bucket := range buckets {
 		ctx := logger.SetReqInfo(GlobalContext, &logger.ReqInfo{BucketName: bucket.Name})
-		configData, err := globalBucketMetadataSys.Get(bucket.Name, bucketLifecycleConfig)
+		configData, err := globalBucketMetadataSys.GetConfig(bucket.Name, bucketLifecycleConfig)
 		if err != nil {
 			if errors.Is(err, errConfigNotFound) {
 				continue

--- a/cmd/bucket-policy-handlers.go
+++ b/cmd/bucket-policy-handlers.go
@@ -167,7 +167,7 @@ func (api objectAPIHandlers) GetBucketPolicyHandler(w http.ResponseWriter, r *ht
 	}
 
 	// Read bucket access policy.
-	configData, err := globalBucketMetadataSys.Get(bucket, bucketPolicyConfig)
+	configData, err := globalBucketMetadataSys.GetConfig(bucket, bucketPolicyConfig)
 	if err != nil {
 		if errors.Is(err, errConfigNotFound) {
 			err = BucketPolicyNotFound{Bucket: bucket}

--- a/cmd/bucket-policy.go
+++ b/cmd/bucket-policy.go
@@ -48,7 +48,7 @@ func (sys *PolicySys) Get(bucket string) (*policy.Policy, error) {
 		}
 		return objAPI.GetBucketPolicy(GlobalContext, bucket)
 	}
-	configData, err := globalBucketMetadataSys.Get(bucket, bucketPolicyConfig)
+	configData, err := globalBucketMetadataSys.GetConfig(bucket, bucketPolicyConfig)
 	if err != nil {
 		if !errors.Is(err, errConfigNotFound) {
 			return nil, err
@@ -73,7 +73,7 @@ func (sys *PolicySys) IsAllowed(args policy.Args) bool {
 		// If policy is available for given bucket, check the policy.
 		p, found := sys.bucketPolicyMap[args.BucketName]
 		if !found {
-			configData, err := globalBucketMetadataSys.Get(args.BucketName, bucketPolicyConfig)
+			configData, err := globalBucketMetadataSys.GetConfig(args.BucketName, bucketPolicyConfig)
 			if err != nil {
 				if !errors.Is(err, errConfigNotFound) {
 					logger.LogIf(GlobalContext, err)
@@ -99,7 +99,7 @@ func (sys *PolicySys) IsAllowed(args policy.Args) bool {
 // Loads policies for all buckets into PolicySys.
 func (sys *PolicySys) load(buckets []BucketInfo, objAPI ObjectLayer) error {
 	for _, bucket := range buckets {
-		configData, err := globalBucketMetadataSys.Get(bucket.Name, bucketPolicyConfig)
+		configData, err := globalBucketMetadataSys.GetConfig(bucket.Name, bucketPolicyConfig)
 		if err != nil {
 			if errors.Is(err, errConfigNotFound) {
 				continue

--- a/cmd/bucket-quota.go
+++ b/cmd/bucket-quota.go
@@ -40,7 +40,7 @@ type BucketQuotaSys struct {
 func (sys *BucketQuotaSys) Get(bucketName string) (q madmin.BucketQuota, err error) {
 	q, ok := sys.quotaMap[bucketName]
 	if !ok {
-		configData, err := globalBucketMetadataSys.Get(bucketName, bucketQuotaConfigFile)
+		configData, err := globalBucketMetadataSys.GetConfig(bucketName, bucketQuotaConfigFile)
 		if err != nil {
 			if errors.Is(err, errConfigNotFound) {
 				return q, nil
@@ -79,7 +79,7 @@ func (sys *BucketQuotaSys) Init(buckets []BucketInfo, objAPI ObjectLayer) error 
 func (sys *BucketQuotaSys) load(buckets []BucketInfo, objAPI ObjectLayer) error {
 	for _, bucket := range buckets {
 		ctx := logger.SetReqInfo(GlobalContext, &logger.ReqInfo{BucketName: bucket.Name})
-		configData, err := globalBucketMetadataSys.Get(bucket.Name, bucketQuotaConfigFile)
+		configData, err := globalBucketMetadataSys.GetConfig(bucket.Name, bucketQuotaConfigFile)
 		if err != nil {
 			if errors.Is(err, errConfigNotFound) {
 				continue

--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -414,7 +414,7 @@ func (fs *FSObjects) ListBuckets(ctx context.Context) ([]BucketInfo, error) {
 			continue
 		}
 		var created = fi.ModTime()
-		meta, err := loadBucketMetadata(ctx, fs, fi.Name())
+		meta, err := globalBucketMetadataSys.Get(fi.Name())
 		if err == nil {
 			created = meta.Created
 		} else {

--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -590,7 +590,7 @@ func (sys *NotificationSys) AddRemoteTarget(bucketName string, target event.Targ
 func (sys *NotificationSys) load(buckets []BucketInfo, objAPI ObjectLayer) error {
 	for _, bucket := range buckets {
 		ctx := logger.SetReqInfo(GlobalContext, &logger.ReqInfo{BucketName: bucket.Name})
-		configData, err := globalBucketMetadataSys.Get(bucket.Name, bucketNotificationConfig)
+		configData, err := globalBucketMetadataSys.GetConfig(bucket.Name, bucketNotificationConfig)
 		if err != nil {
 			if errors.Is(err, errConfigNotFound) {
 				continue


### PR DESCRIPTION
### Change memory representation

Make `map[string]BucketMetadata` take a non-pointer type. 

`nil` has no meaning here. It also makes ownership of data more clear, since shallow copies are returned they can be updated without risking races. 

It also takes less memory and removes an indirection, but that is just bonus.

### Make Get return all metadata

Change `Get` to return all metadata and have `GetConfig` for legacy/specific stuff.

### Remove fallback when server is initialized.

After all buckets have been loaded remove fallback to disk when a bucket config isn't found.

I assume the intention is for the data in RAM to be reliable and the fallback is for requests during startup.

### Update old stuff

Change the old calls to `loadBucketMetadata(ctx, z, bucket)` to use the new system.

