### PR TITLE
Block while frozen

### DIFF
--- a/cmd/admin-handlers.go
+++ b/cmd/admin-handlers.go
@@ -36,7 +36,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/dustin/go-humanize"
@@ -246,9 +245,9 @@ func (a adminAPIHandlers) ServiceHandler(w http.ResponseWriter, r *http.Request)
 
 	switch serviceSig {
 	case serviceFreeze:
-		atomic.CompareAndSwapInt32(&globalServiceFreeze, 0, 1)
+		freezeServices()
 	case serviceUnFreeze:
-		atomic.CompareAndSwapInt32(&globalServiceFreeze, 1, 0)
+		unfreezeServices()
 	case serviceRestart, serviceStop:
 		globalServiceSignalCh <- serviceSig
 	}

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/minio/console/restapi"
@@ -325,7 +326,12 @@ var (
 
 	globalConsoleSrv *restapi.Server
 
-	globalServiceFreeze int32 // toggles service freeze or un-freeze S3 API calls.
+	// handles service freeze or un-freeze S3 API calls.
+	globalServiceFreeze atomic.Value
+
+	// Only needed for tracking
+	globalServiceFreezeCnt int32
+	globalServiceFreezeMu  sync.Mutex // Updates.
 
 	// Add new variable global values here.
 )

--- a/cmd/notification.go
+++ b/cmd/notification.go
@@ -29,7 +29,6 @@ import (
 	"sort"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/bits-and-blooms/bloom/v3"
@@ -1526,9 +1525,9 @@ func (sys *NotificationSys) ServiceFreeze(ctx context.Context, freeze bool) []No
 	}
 	nerrs := ng.Wait()
 	if freeze {
-		atomic.CompareAndSwapInt32(&globalServiceFreeze, 0, 1)
+		freezeServices()
 	} else {
-		atomic.CompareAndSwapInt32(&globalServiceFreeze, 1, 0)
+		unfreezeServices()
 	}
 	return nerrs
 }

--- a/cmd/peer-rest-server.go
+++ b/cmd/peer-rest-server.go
@@ -827,9 +827,9 @@ func (s *peerRESTServer) SignalServiceHandler(w http.ResponseWriter, r *http.Req
 	case serviceStop:
 		globalServiceSignalCh <- signal
 	case serviceFreeze:
-		atomic.CompareAndSwapInt32(&globalServiceFreeze, 0, 1)
+		freezeServices()
 	case serviceUnFreeze:
-		atomic.CompareAndSwapInt32(&globalServiceFreeze, 1, 0)
+		unfreezeServices()
 	case serviceReloadDynamic:
 		objAPI := newObjectLayerFn()
 		if objAPI == nil {

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -67,3 +67,57 @@ func restartProcess() error {
 	// Re-uses the same pid. This preserves the pid over multiple server-respawns.
 	return syscall.Exec(argv0, os.Args, os.Environ())
 }
+
+// Keep track of number of freeze/unfreeze calls.
+const trackFreezeCount = true
+
+// freezeServices will freeze all incoming S3 API calls.
+// For each call, unfreezeServices must be called once.
+func freezeServices() {
+	// Use atomics for globalServiceFreeze, so we can read without locking.
+	if trackFreezeCount {
+		// We need a lock since we are need the 2 atomic values to remain in sync.
+		globalServiceFreezeMu.Lock()
+		// If multiple calls, first one creates channel.
+		globalServiceFreezeCnt++
+		if globalServiceFreezeCnt == 1 {
+			globalServiceFreeze.Store(make(chan struct{}))
+		}
+		globalServiceFreezeMu.Unlock()
+	} else {
+		// If multiple calls, first one creates channel.
+		globalServiceFreeze.CompareAndSwap(nil, make(chan struct{}))
+	}
+}
+
+// unfreezeServices will unfreeze all incoming S3 API calls.
+// For each call, unfreezeServices must be called once.
+func unfreezeServices() {
+	if trackFreezeCount {
+		// We need a lock since we need the 2 atomic values to remain in sync.
+		globalServiceFreezeMu.Lock()
+		// Close when we reach 0
+		globalServiceFreezeCnt--
+		if globalServiceFreezeCnt <= 0 {
+			// Ensure we only close once.
+			if val := globalServiceFreeze.Load(); val != nil {
+				if ch, ok := val.(chan struct{}); ok {
+					globalServiceFreeze.Store(nil)
+					close(ch)
+				}
+			}
+			globalServiceFreezeCnt = 0 // Don't risk going negative.
+		}
+		globalServiceFreezeMu.Unlock()
+	} else {
+		// If multiple calls, first one closes channel.
+		if val := globalServiceFreeze.Load(); val != nil {
+			if ch, ok := val.(chan struct{}); ok {
+				// Ensure we only close once.
+				if globalServiceFreeze.CompareAndSwap(val, nil) {
+					close(ch)
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Description

Block instead of reject while frozen.

I added an implementation that also keeps track of the freeze/unfreeze count, ex/disabled with `trackFreezeCount`. Use whichever you think is appropriate.

## Motivation and Context

Less disruptive speedtests.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
